### PR TITLE
[修复]空出一行导致格式不对

### DIFF
--- a/main.py
+++ b/main.py
@@ -166,7 +166,7 @@ class Relationship(Star):
                 f"群名称：{group_name}\n"
                 f"群号：{group_id}\n"
                 f"flag：{flag}\n"
-                f"验证信息：{comment}\n"
+                f"验证信息：{comment}"
             )
             if self.is_group_in_blacklist(group_id):
                 notice_to_admin += "❗警告: 该群为黑名单群聊，请谨慎通过，若通过则自动移出黑名单"


### PR DESCRIPTION
修复bug去除多余的\n
我之前使用的是Windows一键部署,插件在群邀请上并没有什么问题。
但我在更改到docker部署后,由于一个多余的\n导致空出一行,在同意群邀请时出现了格式不对的错误,导致同意不了群邀请。
![4b84e9b79864e08def683aab21f9e2af_720](https://github.com/user-attachments/assets/2f7306ea-52fe-4775-bcdb-8033332324ff)

## Sourcery 总结

错误修复:
- 移除多余的换行符，该换行符导致在 Docker 部署下批准群组邀请时出现空行和格式错误

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove redundant newline causing blank line and format errors when approving group invitations under Docker deployment

</details>